### PR TITLE
Add ohrwurm track attendees

### DIFF
--- a/src/components/molecules/tables/TrackTable/index.tsx
+++ b/src/components/molecules/tables/TrackTable/index.tsx
@@ -4,9 +4,11 @@
 import React from "react";
 //> MDB
 // "Material Design for Bootstrap" is a great UI design framework
-import { MDBDataTableV5, MDBIcon, MDBBadge } from "mdbreact";
+import { MDBDataTableV5, MDBIcon, MDBBadge, MDBChip } from "mdbreact";
 //> Audio Player
 import ReactPlayer from "react-player";
+//> Moment
+import moment from "moment";
 
 //> Store Types
 import { Track } from "../../../../store/types";
@@ -23,7 +25,15 @@ class TrackTable extends React.Component<
   generateRows = () => {
     return this.props.entries.map((e) => {
       console.log(e);
-      const { id, title, createdAt, tags, transcript, audioFileUrl } = e;
+      const {
+        id,
+        title,
+        createdAt,
+        tags,
+        attendees,
+        transcript,
+        audioFileUrl,
+      } = e;
       return {
         id,
         name: title,
@@ -37,6 +47,13 @@ class TrackTable extends React.Component<
               >
                 {tag.name}
               </MDBBadge>
+            ))}
+          </>
+        ),
+        attendees: (
+          <>
+            {attendees?.map((attendee) => (
+              <MDBChip waves>{attendee.name}</MDBChip>
             ))}
           </>
         ),
@@ -80,6 +97,11 @@ class TrackTable extends React.Component<
       {
         label: "Tags",
         field: "tags",
+        width: 300,
+      },
+      {
+        label: "Attendees",
+        field: "attendees",
         width: 300,
       },
       {

--- a/src/store/actions/ohrwurmActions.ts
+++ b/src/store/actions/ohrwurmActions.ts
@@ -43,6 +43,11 @@ const trackQueryFragment = `
       significance
     }
   }
+  attendees {
+    ... on AttendeeBlock {
+      name
+    }
+  }
   transcript
   pac {
     ${pacQueryFragment}

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -72,6 +72,7 @@ export interface Track {
   createdAt: string;
   description: string;
   tags: { name: string; significance: string }[];
+  attendees: { name: string }[];
   transcript: string;
   pac: PAC;
   audioFileUrl: string;


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->

-   [x] Have you added an explanation of what your changes do and why you'd like them to be included?
-   [ ] Have you updated or added documentation for the change?
-   [x] Have you tested your changes with successful results?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Documentation (non-breaking change which adds documentation)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**
- Currently track attendees are now queried and displayed in the track table. #3 

**What is the new behavior (if this is a feature change)?**
- Now track attendees are queried from a ohrwurm ms and displayed in the track table. Closes #3

**Other information**:
### Track list overview:
![image](https://user-images.githubusercontent.com/52858351/100685896-89289980-337d-11eb-8157-0862ec695a91.png)

